### PR TITLE
Usage without mandatory arguments should not raise an exception

### DIFF
--- a/src/Argu/ArgumentParser.fs
+++ b/src/Argu/ArgumentParser.fs
@@ -76,6 +76,8 @@ and ArgumentParser<'Template when 'Template :> IArgParserTemplate> internal (?us
 
             if cliResults.HelpArgs > 0 && raiseOnUsage then raise HelpText
 
+            let ignoreMissing = (cliResults.HelpArgs > 0 && not raiseOnUsage) || ignoreMissing
+
             let results = combine argInfo ignoreMissing None (Some cliResults.ParseResults)
 
             ParseResults<_>(s, errorHandler, results, cliResults.HelpArgs > 0)

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -224,3 +224,15 @@ module ``Simple Tests`` =
         let args = [| "--mandatory-arg" ; "true" ; "/D" |]
         let results = parser.ParseCommandLine args
         results.Contains <@ Detach @> |> should equal true
+
+        [<Test; ExpectedException(typeof<ArgumentException>)>]
+    let ``20. Should fail wenn Usage, Mandatory and raiseOnUsage = true`` () =
+        let args = [| "/h" |]
+        let _ = parser.ParseCommandLine (args, raiseOnUsage = true)
+        ()
+
+    [<Test>]
+    let ``21. Usage, Mandatory and raiseOnusage = false`` () =
+        let args = [| "/h" |]
+        let results = parser.ParseCommandLine (args, raiseOnUsage = false)
+        results.IsUsageRequested |> should equal true

--- a/tests/Argu.Tests/Tests.fs
+++ b/tests/Argu.Tests/Tests.fs
@@ -224,7 +224,6 @@ module ``Simple Tests`` =
         let args = [| "--mandatory-arg" ; "true" ; "/D" |]
         let results = parser.ParseCommandLine args
         results.Contains <@ Detach @> |> should equal true
-
     
     [<Test; ExpectedException(typeof<ArgumentException>)>]
     let ``20. Should fail wenn Usage, Mandatory and raiseOnUsage = true`` () =


### PR DESCRIPTION
It is actually a fix for #31